### PR TITLE
Fixed redis env in server deployment file

### DIFF
--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -18,9 +18,9 @@ spec:
           ports:
             - containerPort: 5000
           env:
-            - name: REDIS-HOST
+            - name: REDIS_HOST
               value: redis-cluster-ip-service
-            - name: REDIS-PORT
+            - name: REDIS_PORT
               value: '6379'
             - name: PGUSER
               value: postgres


### PR DESCRIPTION
This was the error that was killing me and explains why the redis host didnt see any traffic in the logs.
